### PR TITLE
use additionalProperties, not patternProperties

### DIFF
--- a/src/schemas/types.json
+++ b/src/schemas/types.json
@@ -58,28 +58,24 @@
         },
         "BooleanMap": {
             "type": "object",
-            "patternProperties": {
-                "^.*$": {
-                    "type": "boolean"
-                }
+            "additionalProperties": {
+                "type": "boolean"
             }
         },
         "FlatMap": {
             "type": "object",
-            "patternProperties": {
-                "^.*$": {
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "boolean"
-                        }
-                    ]
-                }
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "number"
+                    },
+                    {
+                        "type": "boolean"
+                    }
+                ]
             }
         },
         "LocalizedString": {
@@ -91,10 +87,8 @@
                 },
                 {
                     "type": "object",
-                    "patternProperties": {
-                        ".*": {
-                            "type": "string"
-                        }
+                    "additionalProperties": {
+                        "type": "string"
                     }
                 }
             ],


### PR DESCRIPTION
This PR migrates `BooleanMap` and `FlatMap` to use the `additionalProperties` syntax, e.g.:

```
"additionalProperties": {
  "type": "boolean"
}
```

instead of `patternProperties`:

```
{
  "patternProperties": {
    "^.*$": {
      "type": "boolean"
    }
  }
}
```

Because the patternProperties schema isn't fully expressible in TypeScript.

Related PR:
https://github.com/rdkcentral/firebolt-openrpc/pull/25
