### PR TITLE
Unify Core & Manage Network Schemas

### DIFF
--- a/src/schemas/network.json
+++ b/src/schemas/network.json
@@ -14,7 +14,16 @@
       "title": "NetworkType",
       "description": "Type of Network connected to the device.",
       "type": "string",
-      "enum": ["wifi", "ethernet", "none"]
+      "enum": ["wifi", "ethernet", "hybrid", "none"]
+    },
+    "NetworkState": {
+      "title": "NetworkState",
+      "type": "string",
+      "enum": [
+        "connected",
+        "disconnected"
+      ],
+      "description": "Connection status to the router, as a string enumeration."
     },
     "NetworkStatus": {
         "title": "NetworkStatus",
@@ -25,7 +34,10 @@
             "type": "boolean",
             "description": "Connection status to the router."
           },
-          "interface": {
+          "state": {
+            "$ref": "#/definitions/NetworkState"
+          },
+          "type": {
             "$ref": "#/definitions/NetworkType"
           }
         }


### PR DESCRIPTION
Core's Device.network() API returns:

```
{
  state: 'connected' | 'disconnected',
  type: 'wifi' | 'ethernet' | 'hybrid'
}
```

And Manage returns:

```
{
  connection: true | false,
  interface: 'wifi' | 'ethernet' | 'none'
}
```

We can't change Core... It's being used by apps, but we can add values to the fields in Manage, and rename the fields to match:

```
{
  connected: true | false
  state: 'connected' | 'disconnected',
  type: 'wifi' | 'ethernet' | 'hybrid' | 'none'
}
```

Related PR:
https://github.com/rdkcentral/firebolt-core-sdk/pull/30