### PR TITLE
Feature/dimensions and image types

### DIFF
--- a/src/schemas/types.json
+++ b/src/schemas/types.json
@@ -1,20 +1,6 @@
 {
     "$id": "https://meta.comcast.com/firebolt/types",
     "title": "Types",
-    "anyOf": [
-        {
-            "$ref": "#/definitions/SemanticVersion"
-        },
-        {
-            "$ref": "#/definitions/BooleanMap"
-        },
-        {
-            "$ref": "#/definitions/AudioProfile"
-        },
-        {
-            "$ref": "#/definitions/LocalizedString"
-        }
-    ],
     "definitions": {
         "SemanticVersion": {
             "title": "SemanticVersion",
@@ -160,6 +146,48 @@
             "default": 0,
             "minimum": 0,
             "maximum": 9999
+        },
+        "Dimensions": {
+            "type": "object",
+            "properties": {
+                "width": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "required": [ "width", "height" ]
+        },
+        "Image": {
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "URI for the image. May be a relative path (e.g. ./foo/image.png) or absolute (e.g. https://foo.com/bar.png) depending on usage.",
+                    "type": "string"
+                },
+                "aspectRatio": {
+                    "description": "The aspect ratio of the image",
+                    "type": "string",
+                    "pattern": "^\\d+x\\d+"
+                },
+                "description": {
+                    "description": "Description of the image.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the image.",
+                    "type": "string",
+                    "enum": [
+                        "icon", "poster", "banner", "splash", "hero"
+                    ]
+                }
+            },
+            "required": [
+                "uri", "aspectRatio", "type"
+            ]
         }
     }
 }


### PR DESCRIPTION
- Added Dimensions type
- Added Image type
- Changed image aspect ratio to use a regex not an enum, per KP's suggestion
- Removed anyOf, which was incomplete anyway
- Note: This is essentially a re-do of the branch feature/add-dimensions-and-image-types and PR 17, but directly on the bumblebee branch
