### PR TITLE
Correct placement of additionalProperties

### DIFF
--- a/src/schemas/capabilities.json
+++ b/src/schemas/capabilities.json
@@ -71,9 +71,9 @@
                 },
                 "overridable": {
                     "type": "boolean"
-                },
-                "additionalProperties": false
-            }
+                }
+            },
+            "additionalProperties": false
         },
         "PrivacySetting": {
             "type": "object",


### PR DESCRIPTION
The `additionalProperties` value cannot be present as a `bool` value inside the `properties` object.  This corrects that so that the schema can be compiled.